### PR TITLE
Log to File Active at Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,18 @@ This plugin integrates a customizable Pomodoro timer into your Obsidian workspac
 -   **Customizable Timer**: Set your work and break intervals to suit your productivity style.
 -   **Audible Alerts**: Stay on track with audio notifications signaling the end of each session.
 -   **Status Bar Display**: Monitor your progress directly from Obsidian's status bar to keep focusing.
--   **Daily Note Integration**: Automatically log your sessions in your daily notes for better tracking.
+-   **Daily Note Integration**: Automatically log your sessions in your daily notes (or any other file) for better tracking.
 
 ## Log
 
+### Log path
+You can choose the logging location:
+
+- **Daily note**: a periodic note as created by the Daily Note plugin.
+- **File**: any Markdown-file of your choice.
+- **File Active at Start**: a Markdown-file that was active (open) at the time the timer started (if such a file is absent, the log will be recorded in the Daily note).
+
+The last option can be used for logging into files associated with different activities. For instance, when you have separate files for different projects that you use to track corresponding tasks and overall progress.
 ### Log Format
 
 The standard log formats are as follows

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -5,7 +5,7 @@ import { writable, type Writable } from 'svelte/store'
 import { getTemplater } from 'utils'
 import { moment } from 'obsidian'
 
-type LogFileType = 'DAILY' | 'FILE' | 'NONE'
+type LogFileType = 'ACTIVE' | 'DAILY' | 'FILE' | 'NONE'
 type LogLevel = 'ALL' | 'WORK' | 'BREAK'
 type LogFormat = 'SIMPLE' | 'VERBOSE' | 'CUSTOM'
 
@@ -141,6 +141,7 @@ export default class PomodoroSettings extends PluginSettingTab {
                 NONE: 'None',
                 DAILY: 'Daily note',
                 FILE: 'File',
+                ACTIVE: 'File Active at Start'
             })
             dropdown.setValue(this._settings.logFile)
             dropdown.onChange((value: string) => {


### PR DESCRIPTION
Hello. Thank you for such a nice plugin! I would like to suggest a few additions.

My workflow involves logging into different files corresponding to different tasks. This way, I want to track how much time I've dedicated to specific tasks. Therefore, I added an option to log into the file that was active (open) when I started the timer. I updated the README accordingly.

However, there are a few questionable points:

1. To log into the active file at launch, I need to store it somewhere. I'm currently doing this in `TimerState` — it seems logical, but passing the `TFile` to `saveLog` makes this function more tightly coupled. I don't like it, but I haven't come up with a better solution.
2. It seems that some active files may not be suitable for logging — for example, it could be a Canvas-file. So, I first check if the file exists and if it is a `.md`-file. If not, I log it in Daily. This seems like a very specific solution. I understand if you don't like it.

I would appreciate your feedback. I understand if this complication doesn't suit your taste. I have no problem using my fork of your excellent plugin!