### PR TITLE
Prevent race condition with change append-method

### DIFF
--- a/src/Timer.ts
+++ b/src/Timer.ts
@@ -387,7 +387,8 @@ const getDailyNoteFile = async (): Promise<TFile> => {
 }
 
 const appendFile = async (filePath: string, logText: string): Promise<void> => {
-    await $plugin!.app.vault.adapter.append(filePath, logText)
+    const tfile = $plugin!.app.vault.getAbstractFileByPath(filePath)
+    await $plugin!.app.vault.append(tfile, logText)
 }
 
 const notify = (log: TimerLog) => {


### PR DESCRIPTION
While using my fork in practice, I encountered an unexpected issue. Periodically, the file was not being updated. During the investigation, I noticed that the writing was indeed happening, but Obsidian wasn't recognizing it.

In other words, if I opened the file being written to in VSCode (and likely any other editor), I could see the added text there. However, in the open file in Obsidian, there were no visible changes. If I made some changes in Obsidian afterward, it would overwrite without including the expected appended log.

Unfortunately, I couldn't create a reproducible example. The situation occurred under load — when Obsidian lagged due to the operation of certain plugins. It seemed like a race condition.

No errors were observed during this process. I even added try-catch, but errors weren't caught there either. Later, someone suggested that the [documentation recommends](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Prefer+the+Vault+API+over+the+Adapter+API) using other functions (Note the "Safety" section):

While the file operations in the Adapter API are often more familiar to many developers, the Vault API has two main advantages over the adapter.

Performance: The Vault API has a caching layer that can speed up file reads when the file is already known to Obsidian.
Safety: The Vault API performs file operations serially to avoid any race conditions, for example when reading a file that is being written to at the same time.
Therefore, I propose replacing vault.adapter.append with [vault.append](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts#L4134). I understand that the behavior I observed was related to my fork, where I was logging to the so-called active file. However, if logging into Daily and simultaneously writing something in it, the problem might likely arise.