### PR TITLE
Implement support for periodic-notes's weekly notes

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -91,6 +91,11 @@ export default class Logger {
             return await utils.getDailyNoteFile()
         }
 
+        // use weekly note
+        if (settings.logFile == 'WEEKLY') {
+            return await utils.getWeeklyNoteFile()
+        }
+
         // log to file
         if (settings.logFile === 'FILE') {
             if (settings.logPath) {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -3,9 +3,13 @@ import { DropdownComponent } from 'obsidian'
 import { PluginSettingTab, Setting, moment } from 'obsidian'
 import type { Unsubscriber } from 'svelte/motion'
 import { writable, type Writable } from 'svelte/store'
-import { getTemplater } from 'utils'
+import { 
+  appHasDailyNotesPluginLoaded,
+  appHasWeeklyNotesPluginLoaded,
+  getTemplater
+} from 'utils'
 
-type LogFileType = 'DAILY' | 'FILE' | 'NONE'
+type LogFileType = 'DAILY' | 'WEEKLY' | 'FILE' | 'NONE'
 type LogLevel = 'ALL' | 'WORK' | 'BREAK'
 type LogFormat = 'SIMPLE' | 'VERBOSE' | 'CUSTOM'
 export type TaskFormat = 'TASKS' | 'DATAVIEW'
@@ -184,11 +188,14 @@ export default class PomodoroSettings extends PluginSettingTab {
         new Setting(containerEl).setHeading().setName('Log')
         new Setting(containerEl).setName('Log File').addDropdown((dropdown) => {
             dropdown.selectEl.style.width = '160px'
-            dropdown.addOptions({
-                NONE: 'None',
-                DAILY: 'Daily note',
-                FILE: 'File',
-            })
+            dropdown.addOptions({ NONE: 'None' })
+            if (appHasDailyNotesPluginLoaded()) {
+              dropdown.addOptions({ DAILY: 'Daily note' });
+            }
+            if (appHasWeeklyNotesPluginLoaded()) {
+              dropdown.addOptions({ WEEKLY: 'Weekly note' });
+            }
+            dropdown.addOptions({ FILE: 'File' })
             dropdown.setValue(this._settings.logFile)
             dropdown.onChange((value: string) => {
                 this.updateSettings({ logFile: value as LogFileType }, true)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,11 +4,19 @@ import {
     getDailyNote,
     createDailyNote,
     getAllDailyNotes,
+    getWeeklyNote,
+    createWeeklyNote,
+    getAllWeeklyNotes,
 } from 'obsidian-daily-notes-interface'
 import {
     TaskRegularExpressions,
     type TaskComponents,
 } from 'serializer/TaskModels'
+
+export {
+    appHasDailyNotesPluginLoaded,
+    appHasWeeklyNotesPluginLoaded,
+} from 'obsidian-daily-notes-interface'
 
 export function getTemplater(app: App) {
     return app.plugins.plugins['templater-obsidian']
@@ -98,6 +106,14 @@ export const getDailyNoteFile = async (): Promise<TFile> => {
     const file = getDailyNote(moment() as any, getAllDailyNotes())
     if (!file) {
         return await createDailyNote(moment() as any)
+    }
+    return file
+}
+
+export const getWeeklyNoteFile = async (): Promise<TFile> => {
+    const file = getWeeklyNote(moment() as any, getAllWeeklyNotes())
+    if (!file) {
+        return await createWeeklyNote(moment() as any)
     }
     return file
 }


### PR DESCRIPTION
I do all my planning at the weekly level, and so my daily note is a weekly note.

If one uses the core plugin daily note with a format string of "YYYY-WW" or "gggg-ww", then selecting "Daily note" as the choice for logging will yield a "Cannot create new file" error, because getDailyNote():

1. looks for _daily_ notes
2. doesn't find the weekly notes because they're not daily
3. tries to create a file using the configured daily file name template string
4. the daily file name template string yields a weekly note filename
5. gets an error that the weekly file already exists

The solution here is to lean on obsidian-daily-notes-interface a bit more to detect daily vs weekly notes, and then call the corresponding get/create functions.  It's a bit unfortunate that there's no getPeriodicNote() in the way that there's a createPeriodicNote() to help remove code duplication.

There's a little bonus here that if a user disables their daily note plugin(s), then the option will stop showing up in the listing, which is a minor existing bug.

Also, this is the first time I've ever written typescript, so literally no idea what proper typescript is. :shrug: 