### PR TITLE
Add logging section header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ For those requiring more detailed logging, consider setting up a custom [log tem
 - 🥤 (pomodoro::BREAK) (duration:: 25m) (begin:: 2023-12-20 16:06) - (end:: 2023-12-20 16:07)
 ```
 
+
+### Custom Section Header (Optional)
+
+By default, logs are appended to the end of the file specified in the settings.
+
+If you want to append logs under a specific section header within the file, you can use the "Log section header name" setting. Simply copy and paste the unique section name as plain markdown syntax, including the "#" symbols (e.g., "## Logs header").
+
+
 ### Custom Log Template (Optional)
 
 1. Install the [Templater](https://github.com/SilentVoid13/Templater) plugin.

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -26,6 +26,7 @@ export interface Settings {
     logFile: LogFileType
     logFocused: boolean
     logPath: string
+    logSectionName: string
     logLevel: LogLevel
     logTemplate: string
     logFormat: LogFormat
@@ -47,6 +48,7 @@ export default class PomodoroSettings extends PluginSettingTab {
         logFile: 'NONE',
         logFocused: false,
         logPath: '',
+        logSectionName: '',
         logLevel: 'ALL',
         logTemplate: '',
         logFormat: 'VERBOSE',
@@ -227,6 +229,17 @@ export default class PomodoroSettings extends PluginSettingTab {
                         })
                     })
             }
+
+            new Setting(containerEl)
+            .setName('Log section header name')
+            .setDesc('The section name under which log entries are organized (including # signs)')
+            .addText((text) => {
+                text.inputEl.style.width = '300px'
+                text.setValue(this._settings.logSectionName)
+                text.onChange((value) => {
+                    this.updateSettings({ logSectionName: value })
+                })
+            });
 
             new Setting(containerEl)
                 .setName('Log Level')


### PR DESCRIPTION
Closes #39 

I have tried to add the logic requested in this issue, as I find this feature very useful in my current workflow. 
I added a configuration that allows the user to optionally specify a header under which the log entries should be inserted. I have updated the Logger class to handle this configuration.

Let me know if I've missed anything, this is my first encounter with Obsidian plugin development, thanks! :) 