### PR TITLE
Add a "Continue After Zero" option to notify but not stop at 0

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -59,7 +59,7 @@ export default class Logger {
         return logFile
     }
 
-    private async resolveLogFile(ctx: LogContext): Promise<TFile | void> {
+    public async resolveLogFile(ctx: LogContext): Promise<TFile | void> {
         const settings = this.plugin!.getSettings()
 
         // filter log level
@@ -123,7 +123,7 @@ export default class Logger {
             end: new Date().getTime(),
             session: ctx.duration,
             task: ctx.task,
-            finished: ctx.count == ctx.elapsed,
+            finished: ctx.count <= ctx.elapsed,
         }
     }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -18,6 +18,7 @@ export interface Settings {
     workLen: number
     breakLen: number
     autostart: boolean
+    continueAfterZero: boolean
     useStatusBarTimer: boolean
     notificationSound: boolean
     enableTaskTracking: boolean
@@ -39,6 +40,7 @@ export default class PomodoroSettings extends PluginSettingTab {
         workLen: 25,
         breakLen: 5,
         autostart: false,
+        continueAfterZero: false,
         useStatusBarTimer: false,
         notificationSound: true,
         customSound: '',

--- a/src/StatusBarComponent.svelte
+++ b/src/StatusBarComponent.svelte
@@ -60,6 +60,17 @@ const ctxMenu = (e: MouseEvent) => {
     })
 
     menu.addItem((item) => {
+        item.setTitle('Continue After Zero')
+        item.setChecked($settings.continueAfterZero)
+        item.onClick(() => {
+            settings.update((s) => {
+                s.continueAfterZero = !s.continueAfterZero
+                return s
+            })
+        })
+    })
+
+    menu.addItem((item) => {
         item.setTitle('Sound')
         item.setChecked($settings.notificationSound)
         item.onClick(() => {

--- a/src/Timer.ts
+++ b/src/Timer.ts
@@ -164,7 +164,7 @@ export default class Timer implements Readable<TimerStore> {
         let autostart = false
         this.update((state) => {
             this.notify(state)
-            if (!s.continueAfterZero) {
+            if (!state.continueAfterZero) {
               const ctx = this.createLogContext(state)
               this.processLog(ctx)
               autostart = state.autostart

--- a/src/TimerSettingsComponent.svelte
+++ b/src/TimerSettingsComponent.svelte
@@ -57,6 +57,12 @@ const updateBreakLen = (e: Event) => {
             </div>
         </div>
         <div class="pomodoro-settings-item">
+            <div class="pomodoro-settings-label">Continue After Zero</div>
+            <div class="pomodoro-settings-control">
+                <input type="checkbox" bind:checked={$settings.continueAfterZero} />
+            </div>
+        </div>
+        <div class="pomodoro-settings-item">
             <div class="pomodoro-settings-label">Notification Sound</div>
             <div class="pomodoro-settings-control">
                 <input

--- a/src/TimerViewComponent.svelte
+++ b/src/TimerViewComponent.svelte
@@ -32,6 +32,11 @@ const pause = () => {
     }
 }
 
+const skip = () => {
+    timer.reset()
+    timer.toggleMode()
+}
+
 const toggleTimer = () => {
     timer.toggleTimer()
 }
@@ -179,6 +184,29 @@ const toggleExtra = (value: 'settings' | 'tasks') => {
                     ><path
                         d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
                     /><path d="M3 3v5h5" /></svg
+                >
+            </span>
+            <span on:click={skip} class="control">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="lucide lucide-rotate-ccw"
+                    ><polygon
+                        points="19,12 5,21 5,3 "
+                        id="polygon1"
+                        transform="matrix(0.48966371,0,0,1.0321186,2.26259,-0.38542317)"
+                    /><polygon
+                        points="5,3 19,12 5,21 "
+                        id="polygon2"
+                        transform="matrix(0.48966371,0,0,1.0321186,10.83146,-0.38542317)"
+                    /></svg
                 >
             </span>
             <span


### PR DESCRIPTION
I found myself getting annoyed that I'd be focused on working on something, and would have to keep restarting a pomodoro on the same task. So I made some changes so that it will notify as a reminder, but keep the clock going for when I'm focused working, and I'll manually stop the timer when I'm done.  This is a simpler version version of "flow mode" found in some pomodoro software, of which there's a request for it in #46.  It's probably easiest explained just with a screenshot:

![image](https://github.com/user-attachments/assets/097cbb80-b730-4e8d-8828-447bfd792fd0)

Feel free to request renames/refactors, as this is a bit more invasive of a change.  I'm not in love with the name "Continue After Zero", but I'm failing to think of something short to call it that's more obvious as to what it does.

Aside from adding the new setting, this required:
- Adding a 'Skip' or 'Next' button to do a Reset+Mode Change.  If you want to end your Work and move to Break, this gives you one button to click to do that.
- Making Timer.timeup be called only once upon the completing tick, as there's now many ticks during which `state.elapsed > state.count`.
- Separating logging a completed pomodoro from the notification, so that we can still notify at the intended time, but wait until the user ends the session to log the final duration.  This required exposing resolveLogFile from Logger and a bit of wasteful reconstructing of TimerContext, but it'll only run once anyway.
- Continue After Zero applies equally to Break time.

Checking the "Continue After Zero" box effectively renders Auto-start ignored.  If you have Auto-start checked, and click the skip ▷▷ button, it doesn't start the next pomodoro.  This is because there's no handling of auto-start in Timer.reset... and I'm kind of unclear if there should be?  I could make an actual Timer.skip() to add auto-start handling for this, but if the reset ⟲ button doesn't Auto-start then the skip one probably shouldn't also?

The skip ▷▷ button is just exactly the start button ▷, which I duplicated in inkscape, put it next to the original with a tiny space, and then shrunk the width by 50% so it'd take up about the same amount of space.  I, again, am not really sure what's a good design for this button.

Feedback welcome, and thanks for the great plugin.  If this is a bit out of the scope of what you wanted for the pomodoro plugin, no worries on rejecting the PR.