### PR TITLE
added command to start a new pomodoro for the selected task

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This plugin integrates a customizable Pomodoro timer into your Obsidian workspac
 -   **Status Bar Display**: Monitor your progress directly from Obsidian's status bar to keep focusing.
 -   **Daily Note Integration**: Automatically log your sessions in your daily notes for better tracking.
 -   **Task Tracking**: Automatically refresh the 'actual time' field for the task in focus.
+-   **Quick Start Command**: use the Quick Start Select Task command, which is bindable to a hot key, to select the task, pin it, and start the timer.  Any timer that was already running for another task is logged. 
 
 ## Notification
 

--- a/src/TaskTracker.ts
+++ b/src/TaskTracker.ts
@@ -76,7 +76,17 @@ export default class TaskTracker implements TaskTrackerStore {
     get file() {
         return this.state.file
     }
-
+	
+	public setFile(file: TFile) {
+		this.store.update((state) => {
+			if (state.file?.path !== file?.path) {
+				state.task = undefined
+			}
+			state.file = file ?? state.file
+			return state
+		})
+	}
+	
     public togglePinned() {
         this.store.update((state) => {
             state.pinned = !state.pinned

--- a/src/Tasks.ts
+++ b/src/Tasks.ts
@@ -134,6 +134,10 @@ export default class Tasks implements Readable<TaskStore> {
             }))
         }
     }
+	
+	public getTaskItemByName(taskLine :number){
+		return this.state.list.find((taskItem => taskItem.line == taskLine));
+	}
 
     public clearTasks() {
         this._store.update(() => ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import { TimerView, VIEW_TYPE_TIMER } from 'TimerView'
-import { Notice, Plugin, WorkspaceLeaf } from 'obsidian'
+import { Editor, editorInfoField, MarkdownView, Notice, Plugin, WorkspaceLeaf, type MarkdownFileInfo } from 'obsidian'
 import PomodoroSettings, { type Settings } from 'Settings'
 import StatusBar from 'StatusBarComponent.svelte'
 import Timer from 'Timer'
 import Tasks from 'Tasks'
 import TaskTracker from 'TaskTracker'
+import { quickStartSelectedTask } from 'quickStartSelectedTask'
 
 export default class PomodoroTimerPlugin extends Plugin {
     private settingTab?: PomodoroSettings
@@ -82,7 +83,16 @@ export default class PomodoroTimerPlugin extends Plugin {
                 })
             },
         })
+
+        this.addCommand({
+            id: 'quick-start-selected-task',
+            name: 'Quick Start Selected Task',
+			editorCallback: (editor: Editor, view: MarkdownView | MarkdownFileInfo) => {
+				quickStartSelectedTask(editor, view, this.tracker, this.timer, this.tasks);
+			}
+        })
     }
+
 
     public getSettings(): Settings {
         return (

--- a/src/quickStartSelectedTask.ts
+++ b/src/quickStartSelectedTask.ts
@@ -1,0 +1,46 @@
+import type {Editor, MarkdownFileInfo, MarkdownView} from "obsidian";
+import type TaskTracker from "TaskTracker";
+import Tasks from "./Tasks";
+import type Timer from 'Timer'
+
+export async function quickStartSelectedTask(this: any, editor: Editor, view: MarkdownView | MarkdownFileInfo, tracker: TaskTracker | undefined, timer: Timer | undefined, tasks: Tasks | undefined) {
+	logAnyCurrentTask(timer);
+	unpinExistingFile(tracker);
+	
+	await loadTasksForSelectedFile(tracker, view);
+
+	const lineNumber = getLineNumberOfSelectedTask(editor);
+	const taskItemToSet = tasks?.getTaskItemByName(lineNumber);
+	if(taskItemToSet){
+		tracker?.active(taskItemToSet)
+		tracker?.togglePinned();
+		timer?.start();
+	}
+}
+function logAnyCurrentTask(timer: Timer | undefined) {
+	timer?.reset();
+}
+
+function getLineNumberOfSelectedTask(editor: Editor) {
+	const origCursorPos = editor.getCursor();
+
+	return origCursorPos.line;
+}
+
+function unpinExistingFile(tracker: TaskTracker | undefined) {
+	if (tracker?.pinned) {
+		tracker.togglePinned();
+	}
+}
+
+async function loadTasksForSelectedFile(tracker: TaskTracker | undefined, view: MarkdownView | MarkdownFileInfo) {
+	const file = view.file;
+	if (file) {
+		tracker?.setFile(file);
+		await waitForTasksToBeLoaded(1000);
+	}
+}
+
+function waitForTasksToBeLoaded(ms :number) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
@eatgrass,  I added a new command to allow quick selecting / switching for a selected task on a page.  

It calls reset for any existing task that might have a timer running, so it will be logged.  The existing task is un-pinned and the tasks for the page of the selected task are loaded.  The task is selected in the tracker, pinned, and the timer is started

![image](https://github.com/user-attachments/assets/44eb23e5-fd91-43ee-a3b0-696ffdbb472f)
