### PR TITLE
Add a "Continue After Zero" option to notify but not stop at 0.

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -59,7 +59,7 @@ export default class Logger {
         return logFile
     }
 
-    private async resolveLogFile(ctx: LogContext): Promise<TFile | void> {
+    public async resolveLogFile(ctx: LogContext): Promise<TFile | void> {
         const settings = this.plugin!.getSettings()
 
         // filter log level
@@ -123,7 +123,7 @@ export default class Logger {
             end: new Date().getTime(),
             session: ctx.duration,
             task: ctx.task,
-            finished: ctx.count == ctx.elapsed,
+            finished: ctx.count <= ctx.elapsed,
         }
     }
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -18,6 +18,7 @@ export interface Settings {
     workLen: number
     breakLen: number
     autostart: boolean
+    continueAfterZero: boolean
     useStatusBarTimer: boolean
     notificationSound: boolean
     enableTaskTracking: boolean
@@ -39,6 +40,7 @@ export default class PomodoroSettings extends PluginSettingTab {
         workLen: 25,
         breakLen: 5,
         autostart: false,
+        continueAfterZero: false,
         useStatusBarTimer: false,
         notificationSound: true,
         customSound: '',

--- a/src/StatusBarComponent.svelte
+++ b/src/StatusBarComponent.svelte
@@ -60,6 +60,17 @@ const ctxMenu = (e: MouseEvent) => {
     })
 
     menu.addItem((item) => {
+        item.setTitle('Continue After Zero')
+        item.setChecked($settings.continueAfterZero)
+        item.onClick(() => {
+            settings.update((s) => {
+                s.continueAfterZero = !s.continueAfterZero
+                return s
+            })
+        })
+    })
+
+    menu.addItem((item) => {
         item.setTitle('Sound')
         item.setChecked($settings.notificationSound)
         item.onClick(() => {

--- a/src/TimerSettingsComponent.svelte
+++ b/src/TimerSettingsComponent.svelte
@@ -57,6 +57,12 @@ const updateBreakLen = (e: Event) => {
             </div>
         </div>
         <div class="pomodoro-settings-item">
+            <div class="pomodoro-settings-label">Continue After Zero</div>
+            <div class="pomodoro-settings-control">
+                <input type="checkbox" bind:checked={$settings.continueAfterZero} />
+            </div>
+        </div>
+        <div class="pomodoro-settings-item">
             <div class="pomodoro-settings-label">Notification Sound</div>
             <div class="pomodoro-settings-control">
                 <input

--- a/src/TimerViewComponent.svelte
+++ b/src/TimerViewComponent.svelte
@@ -32,6 +32,11 @@ const pause = () => {
     }
 }
 
+const skip = () => {
+    timer.reset()
+    timer.toggleMode()
+}
+
 const toggleTimer = () => {
     timer.toggleTimer()
 }
@@ -179,6 +184,29 @@ const toggleExtra = (value: 'settings' | 'tasks') => {
                     ><path
                         d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
                     /><path d="M3 3v5h5" /></svg
+                >
+            </span>
+            <span on:click={skip} class="control">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="lucide lucide-rotate-ccw"
+                    ><polygon
+                        points="19,12 5,21 5,3 "
+                        id="polygon1"
+                        transform="matrix(0.48966371,0,0,1.0321186,2.26259,-0.38542317)"
+                    /><polygon
+                        points="5,3 19,12 5,21 "
+                        id="polygon2"
+                        transform="matrix(0.48966371,0,0,1.0321186,10.83146,-0.38542317)"
+                    /></svg
                 >
             </span>
             <span


### PR DESCRIPTION
Aside from adding the new setting, this required:
- Adding a 'Skip' or 'Next' button to do a Reset+Mode Change
- Making Timer.timeup be called only once upon the completing tick
- Separating logging a completed pomodoro from the notification, so that we can still notify at the intended time, but wait until the user ends the session to log the final duration.